### PR TITLE
[Android] cordova plugin add 시 res/drawable-hdpi already exists error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,11 +39,16 @@
     <source-file src="src/android/iamport_activity.xml" target-dir="res/layout" />
     <source-file src="src/android/iamport_actionbar.xml" target-dir="res/layout" />
     <source-file src="src/android/iamport_actionbar_actions.xml" target-dir="res/menu" />
-    <source-file src="src/android/drawable-anydpi" target-dir="res" />
-    <source-file src="src/android/drawable-hdpi" target-dir="res" />
-    <source-file src="src/android/drawable-mdpi" target-dir="res" />
-    <source-file src="src/android/drawable-xhdpi" target-dir="res" />
-    <source-file src="src/android/drawable-xxhdpi" target-dir="res" />
+    <source-file src="src/android/drawable-anydpi/ic_action_back.xml" target-dir="res/drawable-anydpi" />
+    <source-file src="src/android/drawable-anydpi/ic_action_close.xml" target-dir="res/drawable-anydpi" />
+    <source-file src="src/android/drawable-hdpi/ic_action_back.png" target-dir="res/drawable-hdpi" />
+    <source-file src="src/android/drawable-hdpi/ic_action_close.png" target-dir="res/drawable-hdpi" />
+    <source-file src="src/android/drawable-mdpi/ic_action_back.png" target-dir="res/drawable-mdpi" />
+    <source-file src="src/android/drawable-mdpi/ic_action_close.png" target-dir="res/drawable-mdpi" />
+    <source-file src="src/android/drawable-xhdpi/ic_action_back.png" target-dir="res/drawable-xhdpi" />
+    <source-file src="src/android/drawable-xhdpi/ic_action_close.png" target-dir="res/drawable-xhdpi" />
+    <source-file src="src/android/drawable-xxhdpi/ic_action_back.png" target-dir="res/drawable-xxhdpi" />
+    <source-file src="src/android/drawable-xxhdpi/ic_action_close.png" target-dir="res/drawable-xxhdpi" />
     <source-file src="src/android/IamportCordova.java" target-dir="src/kr/iamport/cordova" />
     <source-file src="src/android/IamportActivity.java" target-dir="src/kr/iamport/cordova" />
     <source-file src="src/android/IamportWebViewClient.java" target-dir="src/kr/iamport/cordova" />


### PR DESCRIPTION
ionic deploy 와 같은 자동 CI/CD 시 아래와 같은 에러가 발생합니다.
지난 5월에 기술지원팀에 문의를 드렸으나, 임시 해결이 가능하여 재차 문의를 드리지는 않았었습니다. (https://github.com/iamport/iamport-cordova/issues/6)

Error during processing of action! Attempting to revert...
Failed to install 'iamport-cordova': CordovaError: Uh oh!
"/builds/[project_path]/platforms/android/app/src/main/res/drawable-hdpi" already exists!
    at copyNewFile (/builds/[project_path]/platforms/android/cordova/lib/pluginHandlers.js:234:45)
    at install (/builds/[project_path]/platforms/android/cordova/lib/pluginHandlers.js:34:17)
    at ActionStack.process (/builds/[project_path]/node_modules/cordova-common/src/ActionStack.js:56:25)
    at PluginManager.doOperation (/builds/[project_path]/node_modules/cordova-common/src/PluginManager.js:114:20)
    at PluginManager.addPlugin (/builds/[project_path]/node_modules/cordova-common/src/PluginManager.js:144:17)
    at /builds/[project_path]/platforms/android/cordova/Api.js:210:74
    at _fulfilled (/builds/[project_path]/node_modules/q/q.js:854:54)
    at /builds/[project_path]/node_modules/q/q.js:883:30
    at Promise.promise.promiseDispatch (/builds/[project_path]/node_modules/q/q.js:816:13)
    at /builds/[project_path]/node_modules/q/q.js:877:14
Failed to restore plugin "iamport-cordova" from config.xml. You might need to try adding it again.



아래의 명령어들을 스크립트화 하여 해결 가능하긴 하지만, 보다 나은 해결책 제시드리고자 리퀘스트 남깁니다.
$ cordova plugin remove iamport-cordova
$ cordova platform rm android
$ cordova platform add android
$ cordova plugin add iamport-cordova(url생략)
